### PR TITLE
Add maxSelectedObjects option

### DIFF
--- a/lib/voom/presenters/plugins/geotix_seating_chart/components/chart.rb
+++ b/lib/voom/presenters/plugins/geotix_seating_chart/components/chart.rb
@@ -6,7 +6,7 @@ module Voom
           class Chart < Base
             attr_reader :chart_key, :public_key, :event_id, :hold_on_select, :pricing,
                         :currency, :locale, :price_level_tooltip, :available_categories,
-                        :chart_js_url
+                        :max_selected_objects, :chart_js_url
             def initialize(chart_key, public_key, **attribs, &block)
               @chart_key = chart_key
               @public_key = public_key
@@ -17,9 +17,10 @@ module Voom
               @locale = attribs.delete(:locale){ 'en-US' }
               @price_level_tooltip = attribs.delete(:price_level_tooltip){ 'Select a price level' }
               @available_categories = attribs.delete(:available_categories){ [] }
+              @max_selected_objects = attribs.delete(:max_selected_objects){ nil }
               @chart_js_url = attribs.fetch(:chart_js_url, Settings.config.chart_js_url)
               @component_options = %i(chart_key public_key event_id hold_on_select pricing currency
-                                      locale price_level_tooltip available_categories)
+                                      locale price_level_tooltip available_categories max_selected_objects)
               super(type: :geotix_seating_chart, **attribs, &block)
               expand!
             end

--- a/lib/voom/presenters/plugins/geotix_seating_chart/views/geotix_seating_chart.js
+++ b/lib/voom/presenters/plugins/geotix_seating_chart/views/geotix_seating_chart.js
@@ -22,7 +22,8 @@ class GeotixSeatingChart {
         return formatter.format(price);
       },
       availableCategories: data.available_categories,
-      priceLevelsTooltipMessage: data.price_level_tooltip
+      priceLevelsTooltipMessage: data.price_level_tooltip,
+      maxSelectedObjects: data.max_selected_objects
     };
     chartConfig.onObjectSelected = this.itemSelectionCallback(ADD_ITEM_EVENT);
     chartConfig.onObjectDeselected = this.itemSelectionCallback(REMOVE_ITEM_EVENT);


### PR DESCRIPTION
Make use of maxSelectedObjects options - limits the number of seats a user can select on a chart.