### PR TITLE
fix: Fix object_held "quantity" parameter

### DIFF
--- a/views/assets/js/components/seating_chart.js
+++ b/views/assets/js/components/seating_chart.js
@@ -51,7 +51,11 @@ class SeatingChart {
   // Callback for multiple object selection/deselection
   itemsSelectionCallback(eventName) {
     return (objects, ticketTypes) => {
-      this.dispatchEvent(eventName, this.parseObject(objects[0], ticketTypes[0]));
+      // The set of selected objects is homogeneous, so only the first object is parsed.
+      const data = this.parseObject(objects[0], ticketTypes[0]);
+      data.quantity = objects.length;
+
+      this.dispatchEvent(eventName, data);
     }
   }
 


### PR DESCRIPTION
The seats.io JS seems to have changed how the "object held" event works, and now the quantity of each object needs to be totaled and added to the single object sent from the plugin to the cart.